### PR TITLE
Trim lines before processing

### DIFF
--- a/UEFIPatch/uefipatch.cpp
+++ b/UEFIPatch/uefipatch.cpp
@@ -63,7 +63,7 @@ UINT8 UEFIPatch::patchFromFile(QString path)
         if (line.count() == 0 || line[0] == '#')
             continue;
 
-        QList<QByteArray> list = line.split(' ');
+        QList<QByteArray> list = line.trimmed().split(' ');
         if (list.count() < 3)
             continue;
         


### PR DESCRIPTION
This way UEFIPatch will accept lines without the invisible trailing
space character.